### PR TITLE
Feature: Allow multiple entry points

### DIFF
--- a/public/api/.htaccess
+++ b/public/api/.htaccess
@@ -1,0 +1,16 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Redirect Trailing Slashes If Not A Folder...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.*)/$ /$1 [L,R=301]
+
+    # Handle Front Controller...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+
+    # Handle Authorization Header
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+</IfModule>

--- a/public/api/index.php
+++ b/public/api/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
@@ -24,7 +24,7 @@ $container->alias(\Framework\Router::class, RestActionRouter::class);
 /**
  * Initialise DB connection
  */
-$dbh = new \PDO('sqlite:' . __DIR__ . '/../build/db.sqlite');
+$dbh = new \PDO('sqlite:' . __DIR__ . '/../../build/db.sqlite');
 $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 $container->share($dbh);
 
@@ -37,13 +37,13 @@ Type::addType(
 );
 
 $config = Setup::createXMLMetadataConfiguration(
-    [ __DIR__ . '/../src/Sdr/Domain/doctrine-entities'],
+    [ __DIR__ . '/../../src/Sdr/Domain/doctrine-entities'],
     false
 );
 $entityManager = EntityManager::create(
     [
         'driver' => 'pdo_sqlite',
-        'path' =>  __DIR__ . '/../build/db.sqlite',
+        'path' =>  __DIR__ . '/../../build/db.sqlite',
     ],
     $config
 );


### PR DESCRIPTION
Move document root for the API into it's own folder.

This will allow for testing multiple ways of connection to the application.